### PR TITLE
Update RestModule.cs

### DIFF
--- a/RestModule.cs
+++ b/RestModule.cs
@@ -177,7 +177,7 @@ namespace Nancy.Rest.Module
                     {
                         Verb = r.Verb,
                         Route = r.Route,
-                        IsAsync = method.IsAsyncMethod(),
+                        IsAsync = m.IsAsyncMethod(),
                         MethodInfo = method,
                         ContentType = r.ResponseContentType,
                         Parameters = result.Item2


### PR DESCRIPTION
The "method" variable returns the method info of an interface in case the class is an implementation of that interface. Since it's not possible to decorate interface by AsyncStateMachineAttribute, the async Route is not created.